### PR TITLE
package: productName and fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron-store": "^8.0.1"
       },
       "devDependencies": {
-        "@types/react": "^17.0.38",
+        "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.11",
         "@vitejs/plugin-react": "^1.1.4",
         "electron": "^17.0.0",
@@ -709,9 +709,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -5493,9 +5493,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "17.0.39",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
+      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "vite-react-electron",
+  "productName": "Electron",
+  "private": true,
   "version": "1.0.0",
   "description": "Vite React Electron boilerplate.",
   "author": "草鞋没号 <308487730@qq.com>",
@@ -16,7 +18,7 @@
     "electron-store": "^8.0.1"
   },
   "devDependencies": {
-    "@types/react": "^17.0.38",
+    "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@vitejs/plugin-react": "^1.1.4",
     "electron": "^17.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,10 +1,10 @@
-import os from 'os'
-import { join } from 'path'
 import { app, BrowserWindow, shell } from 'electron'
+import { release } from 'os'
+import { join } from 'path'
 import './samples/electron-store'
 
-const isWin7 = os.release().startsWith('6.1')
-if (isWin7) app.disableHardwareAcceleration()
+if (release().startsWith('6.1')) app.disableHardwareAcceleration()
+if (process.platform === 'win32') app.setAppUserModelId(app.getName())
 
 if (!app.requestSingleInstanceLock()) {
   app.quit()


### PR DESCRIPTION
#### 1. In `package.json`
- Bumped `@types/react` to the latest version
- Added `private` property, this prevents the package from accidental publishing, better to add this IMO
- Added `productName` property. This helps Electron to understand the real name of the application. Every time Electron needs your application name, it will prefer `productName` over `name`. For example, the application local folder in `AppData/Local` will have a name that is specified in the `productName` property. When calling app.getName() it will return `productName` of the application if it exists. [See docs for more information](https://www.electronjs.org/docs/latest/api/app#appgetname). Also, this change helped in my further changes, see below

#### 2. In `src/main/index.ts`
- Changed imports a little
- Deleted variable that is used only one time and moved its value into the `if` statement
- Added another `if` statement which fixes the application name in different situations. For example, when calling `Notification`, it will appear with "electron.app.Electron" as the application name, this change fixes this issue by replacing it with the actual application name. [See on StackOverflow](https://stackoverflow.com/questions/65859634/notification-from-electron-shows-electron-app-electron)