### PR TITLE
fix: fix spawn EINVAL error in latest node

### DIFF
--- a/.vscode/.debug.script.mjs
+++ b/.vscode/.debug.script.mjs
@@ -17,6 +17,7 @@ spawn(
   process.platform === 'win32' ? 'npm.cmd' : 'npm',
   ['run', 'dev'],
   {
+    shell: true,
     stdio: 'inherit',
     env: Object.assign(process.env, { VSCODE_DEBUG: 'true' }),
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

error in node 20.16.0:

![image](https://github.com/user-attachments/assets/6f82baf1-7b08-494c-a71e-d28bda72a5b8)


https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
