### PR TITLE
fix: Deprecation of the artifact actions v3 used on build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release_on_${{ matrix. os }}
+          name: release_on_${{ matrix.os }}
           path: release/
           retention-days: 5


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fix the Deprecation of the artifact actions v3 changed to v4
GitHub Deprecation Notice: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Without this change no more artifact upload.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
