### PR TITLE
fix: prevent disabling GPU on the latest Linux kernels

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -29,7 +29,7 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
   : RENDERER_DIST
 
 // Disable GPU Acceleration for Windows 7
-if (os.release().startsWith('6.1')) app.disableHardwareAcceleration()
+if (process.platform === 'win32' && os.release().startsWith('6.1')) app.disableHardwareAcceleration()
 
 // Set application name for Windows 10+ notifications
 if (process.platform === 'win32') app.setAppUserModelId(app.getName())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR fixes a critical bug where hardware acceleration (GPU, WebGL, WebGPU) is unintentionally disabled for Linux users running kernel versions `6.1` and higher (e.g., modern Debian 13, Ubuntu 24.04).

### What is the problem?
Currently, in `index.ts`, there is the following check:
`if (os.release().startsWith('6.1')) app.disableHardwareAcceleration()`

This was clearly intended to disable hardware acceleration on Windows 7 (which has the NT kernel version `6.1`). However, on Linux, `os.release()` returns the Linux kernel version. Since modern Linux distributions are now using kernel `6.1.x` and above, the `startsWith('6.1')` condition incorrectly evaluates to `true`, forcing the Electron app into a software rendering fallback (SwiftShader) and completely killing GPU performance.

### How does this PR fix it?
Added a strict `process.platform === 'win32'` check before evaluating the OS release version.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
